### PR TITLE
[FIX] l10n_cl_counties: incompatible behaviour between differents localizations

### DIFF
--- a/l10n_cl_counties/models/res_partner.py
+++ b/l10n_cl_counties/models/res_partner.py
@@ -15,7 +15,7 @@ class ResPartner(models.Model):
         default=_default_country)
     state_id = fields.Many2one(
         "res.country.state", 'Ubication',
-        domain="[('country_id', '=', country_id), ('type', '=', 'normal'), ('id', '!=', id)]", readonly=True)
+        domain="[('country_id', '=', country_id), ('type', '=', 'normal'), ('id', '!=', id)]")
     real_city = fields.Char('City.')
 
     @api.onchange('city_id', 'city', 'state_id')

--- a/l10n_cl_counties/views/res_partner_view.xml
+++ b/l10n_cl_counties/views/res_partner_view.xml
@@ -28,6 +28,9 @@
                        attrs="{'readonly': [('country_id', '=', %(base.cl)d)], 'invisible': [('state_id', '!=', %(base.state_cl_13)d)]}"
                        foce_save="1"/>
             </xpath>
+            <xpath expr="//field[@name='child_ids']/form//field[@name='state_id']" position="attributes">
+                <attribute name="attrs">{'readonly': [('country_id', '=', %(base.cl)d)]}</attribute>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Steps to reproduce the issue:
- Create a partner
- Set a country, different than Chile
- Add a contact child (e.i. Contact address)
- Can not modify the field state_id