### PR TITLE
[FIX] _docsonline_partner: add missing dependency to sales_team

### DIFF
--- a/l10n_cl_docsonline_partner/__manifest__.py
+++ b/l10n_cl_docsonline_partner/__manifest__.py
@@ -11,6 +11,7 @@
     'depends': [
         'l10n_cl_edi',
         'l10n_cl_counties',
+        'sales_team',
     ],
     'data': [
         'security/ir.model.access.csv',


### PR DESCRIPTION
@Danisan 
si se trata de instalar este modulo en una base nueva da error por una regla de seguridad que intenta crer utilizando un grupo de sales_team.
Agrego la dependencia