### PR TITLE
[FIX]l10n_cl_edi_special_fields: removed duplicate RznSocRecep when partner has no parent

### DIFF
--- a/l10n_cl_edi_special_fields/__manifest__.py
+++ b/l10n_cl_edi_special_fields/__manifest__.py
@@ -14,6 +14,7 @@ Agrega Campos Especiales a los XML
     'website': 'http://blancomartin.cl',
     'depends': [
         'l10n_cl_edi',
+        'sale',
     ],
     'data': [
         'views/partner_view.xml',

--- a/l10n_cl_edi_special_fields/template/dte_template.xml
+++ b/l10n_cl_edi_special_fields/template/dte_template.xml
@@ -5,7 +5,9 @@
             <Receptor position="replace">
                 <Receptor>
                     <RUTRecep t-esc="'55555555-5' if move.partner_id._l10n_cl_is_foreign() else format_vat(move.commercial_partner_id.vat)"/>
-                    <RznSocRecep t-esc="format_length((move.partner_invoice_id.name or '') + ' - ' + move.partner_invoice_id.commercial_partner_id.name or '', 100)"/>
+                    <RznSocRecep t-esc="format_length((move.partner_invoice_id.name or '')
+                                        + (' - ' + move.partner_invoice_id.commercial_partner_id.name or ''
+                                        if move.partner_invoice_id.commercial_partner_id != move.partner_invoice_id else ''), 100)"/>
                     <Extranjero t-if="move.partner_id._l10n_cl_is_foreign()">
                         <NumId t-esc="move.partner_id.vat"/>
                         <IdAdicRecep t-esc="format_length(move.partner_id.country_id.name or move.commercial_partner_id.country_id.name, 20)"/>


### PR DESCRIPTION
<RznSocRecep/> was outputing the name of the partner twice, one for partner_invoice_id and once for partner_invoice_id.commercial_partner_id but in most cases these two are the same.