### PR TITLE
[FIX]l10n_cl_edi_special_fields: fixed errors when no commercial partner

### DIFF
--- a/l10n_cl_edi_special_fields/template/dte_template.xml
+++ b/l10n_cl_edi_special_fields/template/dte_template.xml
@@ -15,7 +15,7 @@
                     <GiroRecep t-if="not move.partner_id._l10n_cl_is_foreign() and not move.l10n_latam_document_type_id._is_doc_type_export() and not move.l10n_latam_document_type_id._is_doc_type_voucher()" t-esc="format_length(move.partner_id.l10n_cl_activity_description, 40)"/>
                     <Contacto t-esc="format_length(move.partner_invoice_id.phone, 80)"/>
                     <CorreoRecep t-if="(move.partner_invoice_id.email or move.commercial_partner_id.l10n_cl_dte_email or move.partner_id.email or move.partner_id.l10n_cl_dte_email) and not move.l10n_latam_document_type_id._is_doc_type_voucher()" t-esc="move.commercial_partner_id.l10n_cl_dte_email or move.partner_id.l10n_cl_dte_email or move.commercial_partner_id.email or move.partner_id.email"/>
-                    <DirRecep t-esc="format_length(move.partner_invoice_id.street or move.commercial_partner_id.street or '' + ' ' + move.partner_invoice_id.street2 or move.commercial_partner_id.street2 or '', 70)"/>
+                    <DirRecep t-esc="format_length((move.partner_invoice_id.street or move.commercial_partner_id.street or '') + ' ' + (move.partner_invoice_id.street2 or move.commercial_partner_id.street2 or ''), 70)"/>
                     <CmnaRecep t-esc="move._l10n_cl_get_comuna_recep()"/>
                 </Receptor>
             </Receptor>
@@ -35,7 +35,7 @@
 
         <template id="dd_subtemplate" inherit_id="l10n_cl_edi.dd_template">
             <RSR position="replace">
-                    <RSR t-esc="format_length((move.partner_invoice_id.name or '') + ' - ' + move.partner_invoice_id.commercial_partner_id.name or '', 40)"/>
+                    <RSR t-esc="format_length((move.partner_invoice_id.name or '') + ' - ' + (move.partner_invoice_id.commercial_partner_id.name or ''), 40)"/>
             </RSR>
         </template>
     </data>


### PR DESCRIPTION
When a partner had no commercial partner (due to migration from older versions) the user couldn't create an invoice/credit note for them