### PR TITLE
14 fix regional office readonly

### DIFF
--- a/l10n_cl_regional_office_automatic/__manifest__.py
+++ b/l10n_cl_regional_office_automatic/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Chile Localization SII Regional Offices",
-    "version": "11.0.1.0.0",
+    "version": "14.0.1.0",
     "author": "Blanco Martín & Asociados",
     "license": "LGPL-3",
     "website": "http://blancomartin.cl",

--- a/l10n_cl_regional_office_automatic/models/res_company.py
+++ b/l10n_cl_regional_office_automatic/models/res_company.py
@@ -1,84 +1,12 @@
-from odoo import api, fields, models
+from odoo import api, models
 
-L10N_CL_SII_REGIONAL_OFFICES_ITEMS = [
-    ('ur_Anc', 'Ancud'),
-    ('ur_Ang', 'Angol'),
-    ('ur_Ant', 'Antofagasta'),
-    ('ur_Ari', 'Arica y Parinacota'),
-    ('ur_Ays', 'Aysén'),
-    ('ur_Cal', 'Calama'),
-    ('ur_Cas', 'Castro'),
-    ('ur_Cau', 'Cauquenes'),
-    ('ur_Cha', 'Chaitén'),
-    ('ur_Chn', 'Chañaral'),
-    ('ur_ChC', 'Chile Chico'),
-    ('ur_Chi', 'Chillán'),
-    ('ur_Coc', 'Cochrane'),
-    ('ur_Cop', 'Concepción '),
-    ('ur_Cos', 'Constitución'),
-    ('ur_Coo', 'Copiapo'),
-    ('ur_Coq', 'Coquimbo'),
-    ('ur_Coy', 'Coyhaique'),
-    ('ur_Cur', 'Curicó'),
-    ('ur_Ill', 'Illapel'),
-    ('ur_Iqu', 'Iquique'),
-    ('ur_LaF', 'La Florida'),
-    ('ur_LaL', 'La Ligua'),
-    ('ur_LaS', 'La Serena'),
-    ('ur_LaU', 'La Unión'),
-    ('ur_Lan', 'Lanco'),
-    ('ur_Leb', 'Lebu'),
-    ('ur_Lin', 'Linares'),
-    ('ur_Lod', 'Los Andes'),
-    ('ur_Log', 'Los Ángeles'),
-    ('ur_Oso', 'Osorno'),
-    ('ur_Ova', 'Ovalle'),
-    ('ur_Pan', 'Panguipulli'),
-    ('ur_Par', 'Parral'),
-    ('ur_Pic', 'Pichilemu'),
-    ('ur_Por', 'Porvenir'),
-    ('ur_PuM', 'Puerto Montt'),
-    ('ur_PuN', 'Puerto Natales'),
-    ('ur_PuV', 'Puerto Varas'),
-    ('ur_PuA', 'Punta Arenas'),
-    ('ur_Qui', 'Quillota'),
-    ('ur_Ran', 'Rancagua'),
-    ('ur_SaA', 'San Antonio'),
-    ('ur_Sar', 'San Carlos'),
-    ('ur_SaF', 'San Felipe'),
-    ('ur_SaD', 'San Fernando'),
-    ('ur_SaV', 'San Vicente de Tagua Tagua'),
-    ('ur_SaZ', 'Santa Cruz'),
-    ('ur_SaC', 'Santiago Centro'),
-    ('ur_SaN', 'Santiago Norte'),
-    ('ur_SaO', 'Santiago Oriente'),
-    ('ur_SaP', 'Santiago Poniente'),
-    ('ur_SaS', 'Santiago Sur'),
-    ('ur_TaT', 'Tal-Tal'),
-    ('ur_Tac', 'Talca'),
-    ('ur_Tah', 'Talcahuano'),
-    ('ur_Tem', 'Temuco'),
-    ('ur_Toc', 'Tocopilla'),
-    ('ur_Vld', 'Valdivia'),
-    ('ur_Val', 'Vallenar'),
-    ('ur_Vlp', 'Valparaíso'),
-    ('ur_Vic', 'Victoria'),
-    ('ur_ViA', 'Villa Alemana'),
-    ('ur_ViR', 'Villarrica'),
-    ('ur_ViM', 'Viña del Mar'),
-]
 
 class ResCompany(models.Model):
     _inherit = 'res.company'
-
-    l10n_cl_sii_regional_office = fields.Selection(
-        L10N_CL_SII_REGIONAL_OFFICES_ITEMS, related='partner_id.l10n_cl_sii_regional_office', readonly=False,
-        translate=False, string='SII Regional Office')
 
     @api.onchange('city_id')
     @api.depends('city_id')
     def _change_regional_office(self):
         if self.country_id != self.env.ref('base.cl'):
             return
-        # self.sudo().l10n_cl_sii_regional_office = self.city_id.l10n_cl_sii_regional_office
-        self.partner_id.sudo().l10n_cl_sii_regional_office = self.city_id.l10n_cl_sii_regional_office
+        self.l10n_cl_sii_regional_office = self.city_id.l10n_cl_sii_regional_office

--- a/l10n_cl_regional_office_automatic/models/res_company.py
+++ b/l10n_cl_regional_office_automatic/models/res_company.py
@@ -72,7 +72,7 @@ class ResCompany(models.Model):
     _inherit = 'res.company'
 
     l10n_cl_sii_regional_office = fields.Selection(
-        L10N_CL_SII_REGIONAL_OFFICES_ITEMS, related='partner_id.l10n_cl_sii_regional_office',
+        L10N_CL_SII_REGIONAL_OFFICES_ITEMS, related='partner_id.l10n_cl_sii_regional_office', readonly=False,
         translate=False, string='SII Regional Office')
 
     @api.onchange('city_id')

--- a/l10n_cl_regional_office_automatic/models/res_partner.py
+++ b/l10n_cl_regional_office_automatic/models/res_partner.py
@@ -1,82 +1,15 @@
 from odoo import api, fields, models
 
-L10N_CL_SII_REGIONAL_OFFICES_ITEMS = [
-    ('ur_Anc', 'Ancud'),
-    ('ur_Ang', 'Angol'),
-    ('ur_Ant', 'Antofagasta'),
-    ('ur_Ari', 'Arica y Parinacota'),
-    ('ur_Ays', 'Aysén'),
-    ('ur_Cal', 'Calama'),
-    ('ur_Cas', 'Castro'),
-    ('ur_Cau', 'Cauquenes'),
-    ('ur_Cha', 'Chaitén'),
-    ('ur_Chn', 'Chañaral'),
-    ('ur_ChC', 'Chile Chico'),
-    ('ur_Chi', 'Chillán'),
-    ('ur_Coc', 'Cochrane'),
-    ('ur_Cop', 'Concepción '),
-    ('ur_Cos', 'Constitución'),
-    ('ur_Coo', 'Copiapo'),
-    ('ur_Coq', 'Coquimbo'),
-    ('ur_Coy', 'Coyhaique'),
-    ('ur_Cur', 'Curicó'),
-    ('ur_Ill', 'Illapel'),
-    ('ur_Iqu', 'Iquique'),
-    ('ur_LaF', 'La Florida'),
-    ('ur_LaL', 'La Ligua'),
-    ('ur_LaS', 'La Serena'),
-    ('ur_LaU', 'La Unión'),
-    ('ur_Lan', 'Lanco'),
-    ('ur_Leb', 'Lebu'),
-    ('ur_Lin', 'Linares'),
-    ('ur_Lod', 'Los Andes'),
-    ('ur_Log', 'Los Ángeles'),
-    ('ur_Oso', 'Osorno'),
-    ('ur_Ova', 'Ovalle'),
-    ('ur_Pan', 'Panguipulli'),
-    ('ur_Par', 'Parral'),
-    ('ur_Pic', 'Pichilemu'),
-    ('ur_Por', 'Porvenir'),
-    ('ur_PuM', 'Puerto Montt'),
-    ('ur_PuN', 'Puerto Natales'),
-    ('ur_PuV', 'Puerto Varas'),
-    ('ur_PuA', 'Punta Arenas'),
-    ('ur_Qui', 'Quillota'),
-    ('ur_Ran', 'Rancagua'),
-    ('ur_SaA', 'San Antonio'),
-    ('ur_Sar', 'San Carlos'),
-    ('ur_SaF', 'San Felipe'),
-    ('ur_SaD', 'San Fernando'),
-    ('ur_SaV', 'San Vicente de Tagua Tagua'),
-    ('ur_SaZ', 'Santa Cruz'),
-    ('ur_SaC', 'Santiago Centro'),
-    ('ur_SaN', 'Santiago Norte'),
-    ('ur_SaO', 'Santiago Oriente'),
-    ('ur_SaP', 'Santiago Poniente'),
-    ('ur_SaS', 'Santiago Sur'),
-    ('ur_TaT', 'Tal-Tal'),
-    ('ur_Tac', 'Talca'),
-    ('ur_Tah', 'Talcahuano'),
-    ('ur_Tem', 'Temuco'),
-    ('ur_Toc', 'Tocopilla'),
-    ('ur_Vld', 'Valdivia'),
-    ('ur_Val', 'Vallenar'),
-    ('ur_Vlp', 'Valparaíso'),
-    ('ur_Vic', 'Victoria'),
-    ('ur_ViA', 'Villa Alemana'),
-    ('ur_ViR', 'Villarrica'),
-    ('ur_ViM', 'Viña del Mar'),
-]
 
 class ResCompany(models.Model):
     _inherit = 'res.partner'
 
-    l10n_cl_sii_regional_office = fields.Selection(
-        L10N_CL_SII_REGIONAL_OFFICES_ITEMS, translate=False, string='SII Regional Office')
+    l10n_cl_sii_regional_office = fields.Selection(related='ref_company_ids.l10n_cl_sii_regional_office',
+        readonly=False)
 
     @api.onchange('city_id')
     @api.depends('city_id')
     def _change_regional_office(self):
         if self.country_id != self.env.ref('base.cl'):
             return
-        self.sudo().l10n_cl_sii_regional_office = self.city_id.l10n_cl_sii_regional_office
+        self.l10n_cl_sii_regional_office = self.city_id.l10n_cl_sii_regional_office

--- a/l10n_cl_regional_office_automatic/views/res_partner_view.xml
+++ b/l10n_cl_regional_office_automatic/views/res_partner_view.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="l10n_cl_edi.view_partner_l10n_cl_edi_form" />
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='l10n_cl_activity_description']" position="after">
-                    <field name="l10n_cl_sii_regional_office" readonly="0" force_save="1"/>
+                    <field name="l10n_cl_sii_regional_office"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
@Danisan we had a ticket (#5021) where when this module was installed, it was not possible to edit the regional office from the company. I uploaded to commits to discuss the solution. To simply solve the problem, we can just implement the first one which adds readonly=False to the regional office in the company.

But, I don't like that when you install this module the previous value of the regional office is erased in every company. This happens because the original column is defined in res.company but the module ignores that and defines a new one in res.partner. So I did a refactor which uses the original field in the company and makes the partner use a related field. I also cleaned up the overwrite of the selection values, since they were outdated and they are not needed due to inheritance.

What do you think?
I will test and forward these changes to 15.0/16.0 after merging. Why was the module removed in 17.0?