### PR TITLE
[ADD]account_more_invoice_space: reduce blank space below header and body's font size

### DIFF
--- a/account_more_invoice_space/__manifest__.py
+++ b/account_more_invoice_space/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2024 Blanco Martín & Asociados (https://www.bmya.cl).
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'More Invoice Space',
+    'summary': 'Reduces padding and margins below the header to the minimum, and reduces the font of the body to 80%.',
+    'version': '1.0.0',
+    'license': 'LGPL-3',
+    'author': 'Blanco Martín & Asociados',
+    'website': 'https://www.bmya.cl',
+    'depends': [
+        'account',
+    ],
+    'data': [
+        'views/report_invoice.xml',
+        'views/report_template.xml',
+    ],
+}

--- a/account_more_invoice_space/__manifest__.py
+++ b/account_more_invoice_space/__manifest__.py
@@ -4,7 +4,7 @@
 {
     'name': 'More Invoice Space',
     'summary': 'Reduces padding and margins below the header to the minimum, and reduces the font of the body to 80%.',
-    'version': '1.0.0',
+    'version': '16.0.1.0.0',
     'license': 'LGPL-3',
     'author': 'Blanco Martín & Asociados',
     'website': 'https://www.bmya.cl',

--- a/account_more_invoice_space/views/report_invoice.xml
+++ b/account_more_invoice_space/views/report_invoice.xml
@@ -1,0 +1,8 @@
+<odoo>
+    <template id="report_invoice_document_mt_0_font_size_80_percent" inherit_id="account.report_invoice_document">
+        <div class="mt-5" position="attributes">
+              <attribute name="class">mt-0</attribute>
+              <attribute name="style">font-size: 0.8em;</attribute>
+        </div>
+    </template>
+</odoo>

--- a/account_more_invoice_space/views/report_template.xml
+++ b/account_more_invoice_space/views/report_template.xml
@@ -1,0 +1,15 @@
+<odoo>
+    <template id="external_layout_standard_pt_0" inherit_id="web.external_layout_standard">
+        <div class="pt-5" position="attributes">
+            <attribute name="class">pt-0</attribute>
+        </div>
+    </template>
+
+    <template id="external_layout_boxed_pt_0" inherit_id="web.external_layout_boxed">
+        <div class="pt-5" position="attributes">
+            <attribute name="class">pt-0</attribute>
+        </div>
+    </template>
+
+    <!-- Bold and Striped layouts do not have pt-5, so they are not modified -->
+</odoo>


### PR DESCRIPTION
Change pt-5 on standard and boxed layouts, and mt-5 on the invoice PDF template to pt-0 and mt-0 respectively.

Reduce font size to 80% on the invoice body