### PR TITLE
[IMP]purchase_order_report,sale_order_report: update deprecated terms

### DIFF
--- a/purchase_order_report/__manifest__.py
+++ b/purchase_order_report/__manifest__.py
@@ -6,7 +6,7 @@
     'summary': """
         This module adapts the purchase order to chilean format
     """,
-    'version': '17.0.1.0',
+    'version': '17.0.1.1.0',
     'license': 'LGPL-3',
     'author': 'Blanco Martín & Asociados',
     'website': 'https://www.bmya.cl',

--- a/purchase_order_report/views/purchase_order_report.xml
+++ b/purchase_order_report/views/purchase_order_report.xml
@@ -51,7 +51,7 @@
                     </div>
                     <div class="row">
                         <div class="col-xs-12">
-                            <span name="company_address" style="font-size: smaller" class="mt0 text-right"
+                            <span name="company_address" style="font-size: smaller" class="mt0 text-end"
                                   t-field="company.l10n_cl_activity_description"/>
                             <br/>
                             <span name="company_address2" style="font-size: smaller">
@@ -115,7 +115,7 @@
     <template id="custom_footer_bmya">
         <div class="footer">
 
-            <div class="text-right" style="border-top: 1px solid black;">
+            <div class="text-end" style="border-top: 1px solid black;">
                 <ul class="list-inline mb4"/>
                 <div name="financial_infos"/>
                 <div class="text-muted">
@@ -215,17 +215,17 @@
                             <th>
                                 <strong>Descripción del Artículo</strong>
                             </th>
-                            <th class="text-right">
+                            <th class="text-end">
                                 <strong>Cant</strong>
                             </th>
                             <t t-if="document_type=='ORDEN DE COMPRA'">
-                                <th class="text-right">
+                                <th class="text-end">
                                     <strong>Precio Unitario</strong>
                                 </th>
-                                <th class="text-right">
+                                <th class="text-end">
                                     <strong>Total</strong>
                                 </th>
-                                <th class="text-right">
+                                <th class="text-end">
                                     <strong>Fecha Entr</strong>
                                 </th>
                             </t>
@@ -243,14 +243,14 @@
                             <td>
                                 <span t-field="line.name"/>
                             </td>
-                            <td class="text-right">
+                            <td class="text-end">
                                 <span t-esc="int(line.product_qty)"/>
                             </td>
                             <t t-if="document_type=='ORDEN DE COMPRA'">
-                                <td class="text-right">
+                                <td class="text-end">
                                     <span t-field="line.price_unit"/>
                                 </td>
-                                <td class="text-right">
+                                <td class="text-end">
                                     <span t-field="line.price_subtotal"
                                           t-options="{&quot;widget&quot;: &quot;monetary&quot;, &quot;xºº&quot;: o.currency_id}"/>
                                 </td>
@@ -274,14 +274,14 @@
                                     <td>
                                         <strong>Subtotal</strong>
                                     </td>
-                                    <td class="text-right">
+                                    <td class="text-end">
                                         <span t-field="o.amount_untaxed"
                                               t-options="{&quot;widget&quot;: &quot;monetary&quot;, &quot;display_currency&quot;: o.currency_id}"/>
                                     </td>
                                 </tr>
                                 <tr>
                                     <td>Impuestos</td>
-                                    <td class="text-right">
+                                    <td class="text-end">
                                         <span t-field="o.amount_tax"
                                               t-options="{&quot;widget&quot;: &quot;monetary&quot;, &quot;display_currency&quot;: o.currency_id}"/>
                                     </td>
@@ -290,7 +290,7 @@
                                     <td>
                                         <strong>Total</strong>
                                     </td>
-                                    <td class="text-right">
+                                    <td class="text-end">
                                         <span t-field="o.amount_total"
                                               t-options="{&quot;widget&quot;: &quot;monetary&quot;, &quot;display_currency&quot;: o.currency_id}"/>
                                     </td>
@@ -306,7 +306,7 @@
                     <table class="table table-sm o_main_table">
                         <tbody>
                             <tr>
-                                <td class="text-left" style="vertical-align: top; width: 7%; font-size: xx-small;">
+                                <td class="text-start" style="vertical-align: top; width: 7%; font-size: xx-small;">
                                     <p>
                                         PARA LA CANCELACIÓN, SERÁ REQUISITO INDISPENSABLE REMITIR LA FACTURA DENTRO DEL
                                         MES
@@ -315,7 +315,7 @@
                                         QUE CONTENGA LA ORDEN DE COMPRA Y ADJUNTAR LA GUÍA DE DESPACHO.
                                     </p>
                                 </td>
-                                <td class="text-left" style="vertical-align: top; width: 7%; font-size: xx-small;">
+                                <td class="text-start" style="vertical-align: top; width: 7%; font-size: xx-small;">
                                     OBSERVACIONES
                                     <br/>
                                     <p t-field="o.notes"/>
@@ -323,18 +323,18 @@
                             </tr>
                             <tr>
                                 <td/>
-                                <td colspan="2" class="text-left"
+                                <td colspan="2" class="text-start"
                                     style="vertical-align: top; width: 7%; font-size: xx-small;">
                                     <span style="font-size: xx-small;">CONDICIONES COMERCIALES:</span>
                                 </td>
                             </tr>
                             <tr>
-                                <td class="text-left" style="vertical-align: top; width: 7%; font-size: xx-small;">
+                                <td class="text-start" style="vertical-align: top; width: 7%; font-size: xx-small;">
                                     Material Puesto en:
                                     <br/>
                                     <span t-field="o.dest_address_id"/>
                                 </td>
-                                <td class="text-left" style="vertical-align: top; width: 7%; font-size: xx-small;">
+                                <td class="text-start" style="vertical-align: top; width: 7%; font-size: xx-small;">
                                     Forma de Pago:
                                     <br/>
                                     <span t-field="o.payment_term_id"/>,
@@ -357,7 +357,7 @@
     <template id="external_layout_striped_bmya">
         <t t-call="purchase_order_report.custom_header_bmya"/>
         <div class="article o_report_layout_striped">
-            <t t-raw="0"/>
+            <t t-out="0"/>
         </div>
         <t t-call="purchase_order_report.custom_footer_bmya"/>
     </template>
@@ -365,7 +365,7 @@
     <template id="external_layout_boxed_bmya">
         <t t-call="purchase_order_report.custom_header_bmya"/>
         <div class="article o_report_layout_boxed">
-            <t t-raw="0"/>
+            <t t-out="0"/>
         </div>
         <t t-call="purchase_order_report.custom_footer_bmya"/>
     </template>
@@ -373,7 +373,7 @@
     <template id="external_layout_bold_bmya">
         <t t-call="purchase_order_report.custom_header_bmya"/>
         <div class="article o_report_layout_bold">
-            <t t-raw="0"/>
+            <t t-out="0"/>
         </div>
         <t t-call="purchase_order_report.custom_footer_bmya"/>
     </template>
@@ -381,7 +381,7 @@
     <template id="external_layout_standard_bmya">
         <t t-call="purchase_order_report.custom_header_bmya"/>
         <div class="article o_report_layout_standard">
-            <t t-raw="0"/>
+            <t t-out="0"/>
         </div>
         <t t-call="purchase_order_report.custom_footer_bmya"/>
     </template>

--- a/sale_order_report/__manifest__.py
+++ b/sale_order_report/__manifest__.py
@@ -6,7 +6,7 @@
     'summary': """
         This module adapts the sale order to chilean format
     """,
-    'version': '17.0.1.0',
+    'version': '17.0.1.1.0',
     'license': 'LGPL-3',
     'author': 'Blanco Martín & Asociados',
     'website': 'https://www.bmya.cl',

--- a/sale_order_report/views/sale_order_report.xml
+++ b/sale_order_report/views/sale_order_report.xml
@@ -44,7 +44,7 @@
                         <img t-if="company.logo" t-att-src="image_data_uri(company.logo)" alt="Logo"/>
                     </div>
                     <div class="row">
-                            <span name="company_address" style="font-size: smaller" class="mt0 text-right"
+                            <span name="company_address" style="font-size: smaller" class="mt0 text-end"
                                   t-field="company.l10n_cl_activity_description"/>
                             <br/>
                             <span name="company_address2" style="font-size: smaller">
@@ -107,7 +107,7 @@
     <template id="custom_footer_bmya">
         <div class="footer">
 
-            <div class="text-right" style="border-top: 1px solid black;">
+            <div class="text-end" style="border-top: 1px solid black;">
                 <ul class="list-inline mb4"/>
                 <div name="financial_infos"/>
                 <div class="text-muted">
@@ -207,17 +207,17 @@
                             <th>
                                 <strong>Descripción del Artículo</strong>
                             </th>
-                            <th class="text-right">
+                            <th class="text-end">
                                 <strong>Cant</strong>
                             </th>
                             <t t-if="document_type=='ORDEN DE COMPRA'">
-                                <th class="text-right">
+                                <th class="text-end">
                                     <strong>Precio Unitario</strong>
                                 </th>
-                                <th class="text-right">
+                                <th class="text-end">
                                     <strong>Total</strong>
                                 </th>
-                                <th class="text-right">
+                                <th class="text-end">
                                     <strong>Fecha Entr</strong>
                                 </th>
                             </t>
@@ -235,14 +235,14 @@
                             <td>
                                 <span t-field="line.name"/>
                             </td>
-                            <td class="text-right">
+                            <td class="text-end">
                                 <span t-esc="int(line.product_uom_qty)"/>
                             </td>
                             <t t-if="document_type=='ORDEN DE COMPRA'">
-                                <td class="text-right">
+                                <td class="text-end">
                                     <span t-field="line.price_unit"/>
                                 </td>
-                                <td class="text-right">
+                                <td class="text-end">
                                     <span t-field="line.price_subtotal"
                                           t-options="{&quot;widget&quot;: &quot;monetary&quot;, &quot;display_currency&quot;: o.currency_id}"/>
                                 </td>
@@ -268,14 +268,14 @@
                                     <td>
                                         <strong>Subtotal</strong>
                                     </td>
-                                    <td class="text-right">
+                                    <td class="text-end">
                                         <span t-field="o.amount_untaxed"
                                               t-options="{&quot;widget&quot;: &quot;monetary&quot;, &quot;display_currency&quot;: o.currency_id}"/>
                                     </td>
                                 </tr>
                                 <tr>
                                     <td>Impuestos</td>
-                                    <td class="text-right">
+                                    <td class="text-end">
                                         <span t-field="o.amount_tax"
                                               t-options="{&quot;widget&quot;: &quot;monetary&quot;, &quot;display_currency&quot;: o.currency_id}"/>
                                     </td>
@@ -284,7 +284,7 @@
                                     <td>
                                         <strong>Total</strong>
                                     </td>
-                                    <td class="text-right">
+                                    <td class="text-end">
                                         <span t-field="o.amount_total"
                                               t-options="{&quot;widget&quot;: &quot;monetary&quot;, &quot;display_currency&quot;: o.currency_id}"/>
                                     </td>
@@ -300,7 +300,7 @@
                     <table class="table table-sm o_main_table">
                         <tbody>
                             <tr>
-                                <td class="text-left" style="vertical-align: top; width: 7%; font-size: xx-small;">
+                                <td class="text-start" style="vertical-align: top; width: 7%; font-size: xx-small;">
                                     <!--<div class="col-xs-6"
                                          style="border-style: solid; border-width: thin; padding-left: 0px; padding-top:0px; padding:bottom: 0px; padding-right: 0px;">-->
                                     <p>
@@ -311,7 +311,7 @@
                                     <!--</div>-->
                                     <!--<br />-->
                                 </td>
-                                <td class="text-left" style="vertical-align: top; width: 7%; font-size: xx-small;">
+                                <td class="text-start" style="vertical-align: top; width: 7%; font-size: xx-small;">
                                     OBSERVACIONES
                                     <br/>
                                     <p t-field="o.note"/>
@@ -319,18 +319,18 @@
                             </tr>
                             <tr>
                                 <td/>
-                                <td colspan="2" class="text-left"
+                                <td colspan="2" class="text-start"
                                     style="vertical-align: top; width: 7%; font-size: xx-small;">
                                     <span style="font-size: xx-small;">CONDICIONES COMERCIALES:</span>
                                 </td>
                             </tr>
                             <tr>
-                                <td class="text-left" style="vertical-align: top; width: 7%; font-size: xx-small;">
+                                <td class="text-start" style="vertical-align: top; width: 7%; font-size: xx-small;">
                                     Material Puesto en:
                                     <br/>
                                     <span t-field="o.partner_shipping_id"/>
                                 </td>
-                                <td class="text-left" style="vertical-align: top; width: 7%; font-size: xx-small;">
+                                <td class="text-start" style="vertical-align: top; width: 7%; font-size: xx-small;">
                                     Forma de Pago:
                                     <br/>
                                     <span t-field="o.payment_term_id"/>,


### PR DESCRIPTION
text-left and text-right are replaced by text-start and text-end in bootstrap 5 replaced some unnecessary t-raw tags with t-out.