### PR TITLE
[IMP] l10n_cl_counties_as_region: Update address info

### DIFF
--- a/l10n_cl_counties_as_region/__init__.py
+++ b/l10n_cl_counties_as_region/__init__.py
@@ -1,0 +1,13 @@
+def post_init_hook(cr, registry):
+    """
+    This update applies to the city, zip, and state_id fields in the res_partner table. It was necessary because the
+    _onchange_city_id method does not trigger upon module installation, leading to incorrect address information by
+    retaining outdated values from the l10n_cl_counties module.
+    """
+    query_to_update_res_partner_info = """
+    UPDATE res_partner AS t SET city = c.name, zip = c.zipcode, state_id = c.state_id 
+    FROM res_city AS c 
+    WHERE t.city_id = c.id AND
+    t.city_id IS NOT NULL;
+    """
+    cr.execute(query_to_update_res_partner_info)

--- a/l10n_cl_counties_as_region/__manifest__.py
+++ b/l10n_cl_counties_as_region/__manifest__.py
@@ -7,7 +7,7 @@
     One application for this is to allow multiple delivery methods and using a rule by comuna instead
     of adding additional entropy to the module.
     """,
-    "version": "16.0.1.0",
+    "version": "16.0.2.0",
     "author": "Blanco Martín & Asociados",
     'license': "LGPL-3",
     "website": "http://blancomartin.cl",
@@ -22,4 +22,5 @@
     ],
     "active": False,
     "installable": True,
+    "post_init_hook": "post_init_hook",
 }


### PR DESCRIPTION
- Added a post-installation hook to update city, zip, and state fields in the address records. This ensures that the address information is correct and up-to-date after installing the module.