### PR TITLE
[FIX]account_move_change_currency: fixed rate conversion

### DIFF
--- a/account_move_change_currency/__manifest__.py
+++ b/account_move_change_currency/__manifest__.py
@@ -9,7 +9,7 @@
         'wizard/account_change_currency_view.xml',
         'views/move_view.xml',
     ],
-    'version': '17.0.1.0',
+    'version': '17.0.1.0.1',
     'website': 'https://www.bmya.cl',
     'license': 'LGPL-3',
     'installable': True,

--- a/account_move_change_currency/wizard/account_change_currency.py
+++ b/account_move_change_currency/wizard/account_change_currency.py
@@ -74,14 +74,10 @@ class AccountChangeCurrency(models.TransientModel):
         move = self._get_move()
         if self.currency_id == move.currency_id:
             return {'type': 'ir.actions.act_window_close'}
-        if self.currency_id == move.company_id.currency_id:
-            rate = self.currency_rate
-        else:
-            rate = 1 / self.currency_rate
         with Form(move) as move_form:
             for i in range(len(move_form.invoice_line_ids)):
                 with move_form.invoice_line_ids.edit(i) as line:
-                    line.price_unit = line.price_unit * rate
+                    line.price_unit = line.price_unit * self.currency_rate
                     line.currency_id = self.currency_id
             if self.currency_rate >= 1:
                 previous_currency = move.currency_id


### PR DESCRIPTION
The conversion should always be done with the wizard's currency_rate. The inverse rate is only there for human readability, and could be used in the message, but not in the conversion.
Currently it is not used in the message either.