### PR TITLE
[ADD]invoice_rate_accounting_date: use accounting date for exchange rate

### DIFF
--- a/invoice_rate_accounting_date/__init__.py
+++ b/invoice_rate_accounting_date/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/invoice_rate_accounting_date/__manifest__.py
+++ b/invoice_rate_accounting_date/__manifest__.py
@@ -1,0 +1,16 @@
+# Copyright 2024 Blanco Martín & Asociados (https://www.bmya.cl).
+
+{
+    'name': 'Invoice Rate from Accounting Date',
+    'summary': 'Accounting date takes precedence over the invoice date for the currencie\'s exchange rate',
+    'version': '17.0.1.0.0',
+    'license': 'LGPL-3',
+    'author': 'Blanco Martín & Asociados',
+    'website': 'https://www.bmya.cl',
+    'depends': [
+        'account',
+    ],
+    'data': [
+    ],
+    'installable': True,
+}

--- a/invoice_rate_accounting_date/models/__init__.py
+++ b/invoice_rate_accounting_date/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_move_line

--- a/invoice_rate_accounting_date/models/account_move_line.py
+++ b/invoice_rate_accounting_date/models/account_move_line.py
@@ -1,0 +1,9 @@
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    def _get_rate_date(self):
+        self.ensure_one()
+        return self.move_id.date or self.move_id.invoice_date or fields.Date.context_today(self)


### PR DESCRIPTION
On vendor bills (and possibly on invoices) use the accounting date over the bill/invoice date to compute the exchange rate for the bill's/invoice's journal items.