### PR TITLE
[ADD] l10n_latam_document_fiscal_position: add this new module

### DIFF
--- a/l10n_latam_document_fiscal_position/__init__.py
+++ b/l10n_latam_document_fiscal_position/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_latam_document_fiscal_position/__manifest__.py
+++ b/l10n_latam_document_fiscal_position/__manifest__.py
@@ -1,0 +1,20 @@
+{
+    'name': 'Latam Document with Fiscal Position',
+    'version': '17.0.1.0.0',
+    'summary': 'Add a Fiscal position linked to Latam Document type',
+    'description': '''
+    When selecting the document type, is very handy, to link that document type with a fiscal position.
+    For example when you use 110 document type in Chile, it is very useful to remove the VAT tax automatically,
+    or for 39 document type in Chile, not to use ILA taxes.
+    ''',
+    'category': 'Localization',
+    'author': 'Blanco Martín & Asociados',
+    'website': 'https://www.bmya.cl',
+    'license': 'LGPL-3',
+    'depends': ['l10n_latam_invoice_document'],
+    'data': [
+        'views/l10n_latam_document_type_view.xml',
+    ],
+    'installable': True,
+    'auto_install': False
+}

--- a/l10n_latam_document_fiscal_position/models/__init__.py
+++ b/l10n_latam_document_fiscal_position/models/__init__.py
@@ -1,0 +1,2 @@
+from . import account_move
+from . import l10n_latam_document_type

--- a/l10n_latam_document_fiscal_position/models/account_move.py
+++ b/l10n_latam_document_fiscal_position/models/account_move.py
@@ -1,0 +1,18 @@
+from odoo import api, models
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    @api.onchange('l10n_latam_document_type_id')
+    def _update_fiscal_position(self):
+        for move in self:
+            if not move.l10n_latam_document_type_id.fiscal_position_id:
+                continue
+            move.fiscal_position_id = move.l10n_latam_document_type_id.fiscal_position_id
+
+    @api.model
+    def create(self, vals):
+        record = super(AccountMove, self).create(vals)
+        record._update_fiscal_position()
+        return record

--- a/l10n_latam_document_fiscal_position/models/l10n_latam_document_type.py
+++ b/l10n_latam_document_fiscal_position/models/l10n_latam_document_type.py
@@ -1,0 +1,7 @@
+from odoo import fields, models, api
+
+
+class L10nLatamDocumentType(models.Model):
+    _inherit = 'l10n_latam.document.type'
+
+    fiscal_position_id = fields.Many2one('account.fiscal.position', string='Fiscal Position')

--- a/l10n_latam_document_fiscal_position/views/l10n_latam_document_type_view.xml
+++ b/l10n_latam_document_fiscal_position/views/l10n_latam_document_type_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="l10n_cl_latam_document_type_view" model="ir.ui.view">
+        <field name="name">l10n.cl.latam.document.fiscal.position</field>
+        <field name="model">l10n_latam.document.type</field>
+        <field name="inherit_id" ref="l10n_latam_invoice_document.view_document_type_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//form" position="attributes">
+                <attribute name="edit">1</attribute>
+            </xpath>
+            <field name="doc_code_prefix" position="after">
+                <field name="fiscal_position_id"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
In some situations, having the document type linked to a fiscal position is useful.
For example, when document type 110 is used (exports in Chile) it is a good idea to remove automatically the taxes with a fiscal position. With this feature, you don't need to configure the fiscal position to the customer, and you can link it directly to the document type.

Another example is if you use doc type 39 (boleta) and your products have alcoholic or nonalcoholic taxes, that are needed only in b2b sales, you can remove the tax for final sales.
