### PR TITLE
[FW] [FIX] update_readme: solo ejecutar en ramas principales (#80)

### DIFF
--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -3,9 +3,14 @@ name: Update README with Odoo Modules
 on:
   push:
     branches:
-      - "*"  # Se ejecuta en todas las ramas
+      - "15.0"
+      - "16.0"
+      - "17.0"
+      - "18.0"
+      - "19.0"
+      - "master"
     paths:
-      - "**/__manifest__.py"  # Solo cuando cambien los archivos __manifest__.py
+      - "**/__manifest__.py"
 
 jobs:
   update-readme:


### PR DESCRIPTION
## Problema
El workflow `update_readme.yml` corre en **todas** las ramas (`branches: "*"`), incluyendo feature branches y forward-port branches (`-fw`).

Esto provoca:
- Un commit extra de README en cada PR (rompe el squash limpio)
- Conflictos en los cherry-picks automáticos del forward-port

## Fix
Restringir a ramas principales: `15.0`, `16.0`, `17.0`, `18.0`, `19.0`, `master`.

El README se actualiza solo después del merge, no durante el desarrollo.

---

Forward-port of #80 (`17.0` → `18.0`).

This PR targets `18.0` and is part of the forward-port chain. Further PRs will be created up to `master`.