### PR TITLE
[ADD] l10n_cl_edi_tpovta_fix: Adds TpoTranVenta Tag to chilean dte xml

### DIFF
--- a/l10n_cl_edi_tpovta_fix/__init__.py
+++ b/l10n_cl_edi_tpovta_fix/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/l10n_cl_edi_tpovta_fix/__manifest__.py
+++ b/l10n_cl_edi_tpovta_fix/__manifest__.py
@@ -1,0 +1,27 @@
+{
+    'name': 'Chile - EDI TpoTranVenta Fix',
+    'version': '17.0.1.0.0',
+    'category': 'Localization/Chile',
+    'license': 'LGPL-3',
+    'icon': '/account/static/description/l10n.png',
+    'sequence': 12,
+    'author': 'Blanco Martín y Asociados',
+    'summary': 'Agrega el campo TpoTranVenta al DTE según el tipo de actividad de venta.',
+    'description': """
+    Agrega el tag <TpoTranVenta> al XML del DTE para documentos que no son boletas ni exportaciones.
+    El valor se determina automáticamente según el tipo de cuentas contables usadas en la factura:
+    - 1: Ventas del giro (por defecto)
+    - 2: Ventas de activo fijo
+    - 3: Otras ventas
+    """,
+    'website': 'http://www.bmya.cl',
+    'depends': [
+        'l10n_cl_edi',
+    ],
+    'data': [
+        'template/dte_template.xml',
+    ],
+    'installable': True,
+    'auto_install': False,
+    'application': False,
+}

--- a/l10n_cl_edi_tpovta_fix/models/__init__.py
+++ b/l10n_cl_edi_tpovta_fix/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_move

--- a/l10n_cl_edi_tpovta_fix/models/account_move.py
+++ b/l10n_cl_edi_tpovta_fix/models/account_move.py
@@ -1,0 +1,22 @@
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    def _l10n_cl_sale_activity(self):
+        account_lines = self.env['account.move.line']._read_group(
+            domain=[
+                ('move_id', '=', self.id),
+                ('tax_line_id', '=', False),
+                ('account_type', 'not in', ['asset_receivable', False])
+            ],
+            groupby=['account_id']
+        )[0][0]
+        income_line_types = account_lines.mapped('account_type')
+        if 'asset_fixed' in income_line_types and 'income' not in income_line_types:
+            return 2
+        elif 'income' not in income_line_types and 'income_other' in income_line_types:
+            return 3
+        else:
+            return 1

--- a/l10n_cl_edi_tpovta_fix/template/dte_template.xml
+++ b/l10n_cl_edi_tpovta_fix/template/dte_template.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<odoo>
+    <data>
+        <template id="dte_subtemplate" inherit_id="l10n_cl_edi.dte_subtemplate">
+            <IndServicio t-if="move.l10n_latam_document_type_id._is_doc_type_voucher()" t-out="'3'" position="after">
+                <TpoTranVenta t-if="not move.l10n_latam_document_type_id._is_doc_type_export() and not move.l10n_latam_document_type_id._is_doc_type_voucher()" t-out="move._l10n_cl_sale_activity()"/>
+            </IndServicio>
+        </template>
+    </data>
+</odoo>

--- a/l10n_cl_edi_tpovta_fix/tests/__init__.py
+++ b/l10n_cl_edi_tpovta_fix/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_l10n_cl_sale_activity

--- a/l10n_cl_edi_tpovta_fix/tests/test_l10n_cl_sale_activity.py
+++ b/l10n_cl_edi_tpovta_fix/tests/test_l10n_cl_sale_activity.py
@@ -1,0 +1,44 @@
+from unittest.mock import MagicMock, patch
+
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestL10nClSaleActivity(TransactionCase):
+    """Tests para _l10n_cl_sale_activity() en account.move.
+
+    Verifica que el método retorne el código correcto de TpoTranVenta según
+    el tipo de cuenta contable utilizada en las líneas de la factura:
+      1 → ventas del giro (por defecto)
+      2 → ventas de activo fijo
+      3 → otras ventas
+    """
+
+    def _make_read_group_result(self, account_types):
+        mock_account = MagicMock()
+        mock_account.mapped.return_value = account_types
+        return [(mock_account,)]
+
+    def test_sale_activity_returns_1_for_regular_income(self):
+        move = self.env['account.move'].new({'move_type': 'out_invoice'})
+        with patch.object(
+            type(self.env['account.move.line']), '_read_group',
+            return_value=self._make_read_group_result(['income'])
+        ):
+            self.assertEqual(move._l10n_cl_sale_activity(), 1)
+
+    def test_sale_activity_returns_2_for_fixed_asset(self):
+        move = self.env['account.move'].new({'move_type': 'out_invoice'})
+        with patch.object(
+            type(self.env['account.move.line']), '_read_group',
+            return_value=self._make_read_group_result(['asset_fixed'])
+        ):
+            self.assertEqual(move._l10n_cl_sale_activity(), 2)
+
+    def test_sale_activity_returns_3_for_other_income(self):
+        move = self.env['account.move'].new({'move_type': 'out_invoice'})
+        with patch.object(
+            type(self.env['account.move.line']), '_read_group',
+            return_value=self._make_read_group_result(['income_other'])
+        ):
+            self.assertEqual(move._l10n_cl_sale_activity(), 3)


### PR DESCRIPTION
Before this PR:
As the value was not present in the xml, it was assumed that the sales are default (your own activity, or code=1).

After the PR:
TpoTranVenta tag is always present:
If the account used in the product is 'other_income' it means that this account is not from your activity. In this case you have two options:

if you are selling a fixed asset you are using the account that is in the plan as "fixed asset sales" and TpoTranVenta will be 2
else you will have code 3
And finally, otherwise, if the account is stock interim account or 'income' account, TpoTranVenta assumes code 1, which will cover most of the cases.

Note:
This is to fix PR https://github.com/odoo/enterprise/pull/106100 in Odoo Enterprise that is not being processed by Odoo SA