### PR TITLE
[FIX] master: bare version + canonical branding + aggregation refs

### DIFF
--- a/account_move_change_currency/__manifest__.py
+++ b/account_move_change_currency/__manifest__.py
@@ -1,5 +1,5 @@
 {
-    'author': 'Blanco Martín & Asociados, Adhoc S.A.',
+    'author': 'Blanco Martín y Asociados SpA',
     'category': 'Accounting & Finance',
     'summary': 'Este módulo permite seleccionar una moneda diferente una vez que se ha creado la factura en borrador, y al hacerlo recorre todas las lineas de la factura y actualiza la moneda y el monto utilizando la tasa previamente seleccionada.',
     'depends': ['account'],
@@ -10,7 +10,7 @@
         'wizard/account_change_currency_view.xml',
         'views/move_view.xml',
     ],
-    'version': '19.0.1.0.0',
+    'version': '1.0.0',
     'website': 'https://www.bmya.cl',
     'license': 'LGPL-3',
     'installable': True,

--- a/account_move_change_currency/security/security.xml
+++ b/account_move_change_currency/security/security.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <data>
         <record model="res.groups" id="group_restrict_change_currency_exchange">

--- a/account_move_change_currency/views/move_view.xml
+++ b/account_move_change_currency/views/move_view.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <record model="ir.ui.view" id="invoice_form">
         <field name="name">account.move.change_currency.view</field>

--- a/account_move_change_currency/wizard/account_change_currency_view.xml
+++ b/account_move_change_currency/wizard/account_change_currency_view.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <data>
         <record id="view_account_change_currency" model="ir.ui.view">

--- a/aggregation.yml
+++ b/aggregation.yml
@@ -1,16 +1,16 @@
 - url: https://github.com/bmya/odoo
-  branch: "19.0"
+  branch: "master"
   merges:
-    - "origin 19.0"
+    - "origin master"
 - url: https://github.com/bmya/enterprise
-  branch: "19.0"
+  branch: "master"
   merges:
-    - "origin 19.0"
+    - "origin master"
 - url: https://github.com/bmya/design-themes
-  branch: "19.0"
+  branch: "master"
   merges:
-    - "origin 19.0"
+    - "origin master"
 - url: https://github.com/bmya/odoo-transbank
-  branch: "19.0"
+  branch: "master"
   merges:
-    - "origin 19.0"
+    - "origin master"

--- a/auth_server_admin_passwd_passkey/__manifest__.py
+++ b/auth_server_admin_passwd_passkey/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 {
     'name': 'Authentification - Admin Passkey',
-    'version': '19.0.1.0.0',
+    'version': '1.0.0',
     'category': 'base',
     'summary': 'Módulo que permite que en servidores el administrador del servidor se identifique como representante de cualquier usuario, con fines de servicio técnico. Cada ingreso queda identificado en la plataforma',
     'description': """
@@ -13,8 +13,8 @@ Functionality :
 * You can now login with any user using server admin password
 (admin_passwd parameter) or with admin user password (superuser password)
     """,
-    'author': 'ADHOC SA',
-    'website': 'www.adhoc.com.ar',
+    'author': 'Blanco Martín y Asociados SpA',
+    'website': 'https://www.bmya.cl',
     'license': 'AGPL-3',
     'depends': [
         'base',

--- a/l10n_cl_counties/__manifest__.py
+++ b/l10n_cl_counties/__manifest__.py
@@ -1,8 +1,8 @@
 {
     "name": "Chile Localization Regions, Cities and Counties",
-    "version": "19.0.1.1.0",
+    "version": "1.1.0",
     "summary": "Agrega un campo de selección basado en el campo oficial city_id a los clientes/proveedores para disponer de las comunas de Chile. Es compatible con l10n_cl y con l10n_cl_edi (facturación electrónica oficial) porque copia el valor de la comuna al campo city.",
-    "author": "Blanco Martín & Asociados",
+    "author": "Blanco Martín y Asociados SpA",
     'license': "LGPL-3",
     "website": "https://www.bmya.cl",
     "category": "Localization/Geopolitical Distribution",

--- a/l10n_cl_counties/views/res_company_view.xml
+++ b/l10n_cl_counties/views/res_company_view.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <record model="ir.ui.view" id="view_company_city_inherit_form">
         <field name="name">res.company.city.form.inherit</field>

--- a/l10n_cl_counties/views/res_partner_view.xml
+++ b/l10n_cl_counties/views/res_partner_view.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <record model="ir.ui.view" id="view_partner_form_states_city_inherit">
         <field name='name'>res.partner.form.states.city.inherit</field>

--- a/l10n_cl_counties_as_region/__manifest__.py
+++ b/l10n_cl_counties_as_region/__manifest__.py
@@ -9,10 +9,10 @@
     of adding additional entropy to the module.
     NOTE: DO NOT INSTALL if you don't need to use delivery methods rules based on comunas.
     """,
-    "version": "19.0.1.0.0",
-    "author": "Blanco Martín & Asociados",
+    "version": "1.0.0",
+    "author": "Blanco Martín y Asociados SpA",
     'license': "LGPL-3",
-    "website": "http://blancomartin.cl",
+    "website": "https://www.bmya.cl",
     "category": "Localization/Geopolitical Distribution",
     "depends": [
         "base",

--- a/l10n_cl_default_document_type/__manifest__.py
+++ b/l10n_cl_default_document_type/__manifest__.py
@@ -7,9 +7,9 @@
         End Consumer: Boleta Electrónica (39)
         Foreigner: Factura de Exportación (110)
     """,
-    'version': '19.0.1.0.0',
+    'version': '1.0.0',
     'category': 'Localization',
-    'author': 'Blanco Martín & Asociados',
+    'author': 'Blanco Martín y Asociados SpA',
     'website': 'https://www.bmya.cl',
     'license': 'LGPL-3',
     'depends': ['l10n_cl'],

--- a/l10n_cl_docsonline_partner/__manifest__.py
+++ b/l10n_cl_docsonline_partner/__manifest__.py
@@ -1,10 +1,10 @@
 {
     "name": """Chile get customer data from www.documentosonline.cl""",
-    'version': '19.0.1.1.1',
+    'version': '1.1.1',
     'category': 'Localization/Chile',
     'sequence': 12,
-    'author':  'Blanco Martín & Asociados',
-    'website': 'http://blancomartin.cl',
+    'author': 'Blanco Martín y Asociados SpA',
+    'website': 'https://www.bmya.cl',
     'license': 'LGPL-3',
     'summary': 'Permite obtener datos tributarios de los clientes conectandose a www.documentosonline.cl. Requiere obtener una API de este sitio. Hay opción de uso gratuito.',
     'depends': [

--- a/l10n_cl_docsonline_partner/data/server_actions.xml
+++ b/l10n_cl_docsonline_partner/data/server_actions.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <data>
         <!-- Server Action for Multiple Update from DocsOnline -->

--- a/l10n_cl_docsonline_partner/views/partner_view.xml
+++ b/l10n_cl_docsonline_partner/views/partner_view.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <data>
         <record id="view_update_button_form" model="ir.ui.view">

--- a/l10n_cl_docsonline_partner/views/res_config_settings.xml
+++ b/l10n_cl_docsonline_partner/views/res_config_settings.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <record id="res_config_settings" model="ir.ui.view">
         <field name="name">res.config.settings.docs.online.connect</field>

--- a/l10n_cl_docsonline_partner/wizard/data_docsonline_view.xml
+++ b/l10n_cl_docsonline_partner/wizard/data_docsonline_view.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <record id="tree_docsonline_partners_view" model="ir.ui.view">
         <field name="name">www.documentosonline.cl possible data</field>

--- a/l10n_cl_edi_fix_validation/__manifest__.py
+++ b/l10n_cl_edi_fix_validation/__manifest__.py
@@ -1,11 +1,11 @@
 {
     'name': 'Chilean Edi Fix Validation',
-    'version': '19.0.1.0.0',
+    'version': '1.0.0',
     'summary': 'Evita rechazos por parte del SII validando campos obligatorios',
     'description': 'Evita rechazos por parte del SII por falta de algunos campos obligatorios. Inicialmente la comuna, '
                    'que se encuentra en el campo Ciudad',
     'category': 'Localization',
-    'author': 'Blanco Martín & Asociados',
+    'author': 'Blanco Martín y Asociados SpA',
     'website': 'https://www.bmya.cl',
     'license': 'OPL-1',
     'depends': [

--- a/l10n_cl_edi_qbli/__manifest__.py
+++ b/l10n_cl_edi_qbli/__manifest__.py
@@ -1,10 +1,10 @@
 {
     "name": """Chile - Add QBLI Field to invoices """,
-    'version': '19.0.1.0.0',
+    'version': '1.0.0',
     'category': 'Localization/Chile',
     'license': 'LGPL-3',
     'sequence': 12,
-    'author':  'Blanco Martín & Asociados',
+    'author': 'Blanco Martín y Asociados SpA',
     'summary': 'Ciertos clientes que usan SAP requieren que el proveedor coloque en el XML de la factura un QBLI, que es un código en cada linea que identifica el ítem de la orden de compra de este cliente.',
     'description': """
 Adds QBLI to the invoice lines, according to requirements from some customers using SAP
@@ -12,7 +12,7 @@ Adds QBLI to the invoice lines, according to requirements from some customers us
 //CdgItem/TpoCodigo
 //CdgItem/VlrCodigo
     """,
-    'website': 'http://bmya.cl',
+    'website': 'https://www.bmya.cl',
     'depends': [
         'l10n_cl_edi',
     ],

--- a/l10n_cl_edi_qbli/template/dte_template.xml
+++ b/l10n_cl_edi_qbli/template/dte_template.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <data>
         <template id="dte_subtemplate" inherit_id="l10n_cl_edi.dte_subtemplate">

--- a/l10n_cl_edi_qbli/views/account_move_view.xml
+++ b/l10n_cl_edi_qbli/views/account_move_view.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
 
     <record id="view_invoice_form" model="ir.ui.view">

--- a/l10n_cl_edi_special_fields/__manifest__.py
+++ b/l10n_cl_edi_special_fields/__manifest__.py
@@ -1,18 +1,18 @@
 {
     "name": """Chile - Legacy Special Fields """,
-    'version': '19.0.1.0.0',
+    'version': '1.0.0',
     'category': 'Localization/Chile',
     'license': 'LGPL-3',
     'icon': '/l10n_cl_partner_extra_xml_identification/static/description/icon.png',
     'sequence': 12,
-    'author':  'Blanco Martín & Asociados',
+    'author': 'Blanco Martín y Asociados SpA',
     'summary': 'Además permite que la deuda en el asiento contable se cargue a la empresa principal a pesar que se facture a una sucursal.',
     'description': """
     Permite emitir la factura a la sucursal de un cliente, y asignar la deuda directamente al cliente real.
     Este módulo se conserva para mantener la compatibilidad con versiones anteriores, pero desde odoo 16 este problema
     puede ser resuelto sin módulos adicionales.
     """,
-    'website': 'http://blancomartin.cl',
+    'website': 'https://www.bmya.cl',
     'depends': [
         'l10n_cl_partner_extra_xml_identification',
     ],

--- a/l10n_cl_edi_special_fields/template/dte_template.xml
+++ b/l10n_cl_edi_special_fields/template/dte_template.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <data>
         <template id="dte_subtemplate" inherit_id="l10n_cl_partner_extra_xml_identification.dte_subtemplate">

--- a/l10n_cl_edi_special_fields/views/account_move_view.xml
+++ b/l10n_cl_edi_special_fields/views/account_move_view.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
 
     <record id="view_invoice_form" model="ir.ui.view">

--- a/l10n_cl_edi_stock_special_fields/__manifest__.py
+++ b/l10n_cl_edi_stock_special_fields/__manifest__.py
@@ -1,16 +1,16 @@
 {
     "name": """Chile - Stock Special Fields """,
-    'version': '19.0.1.0.0',
+    'version': '1.0.0',
     'category': 'Localization/Chile',
     'license': "LGPL-3",
     'sequence': 12,
-    'author':  'Blanco Martín & Asociados',
+    'author': 'Blanco Martín y Asociados SpA',
     'summary': 'Agrega Campos adicionales en el modelo stock como chofer, etc. utilizando el modulo de flota.',
     'description': """
 Agrega Campos Especiales en el modelo stock
 ===========================================
     """,
-    'website': 'http://blancomartin.cl',
+    'website': 'https://www.bmya.cl',
     'depends': [
         'l10n_cl_edi_stock',
         'stock_delivery',

--- a/l10n_cl_edi_stock_special_fields/views/stock_picking.xml
+++ b/l10n_cl_edi_stock_special_fields/views/stock_picking.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <record id="stock_picking_especial_field_form_inherit" model="ir.ui.view">
         <field name="name">stock_picking_especial_field.form</field>

--- a/l10n_cl_edi_tpovta_fix/__manifest__.py
+++ b/l10n_cl_edi_tpovta_fix/__manifest__.py
@@ -1,11 +1,11 @@
 {
     'name': 'Chile - EDI TpoTranVenta Fix',
-    'version': '19.0.1.0.0',
+    'version': '1.0.0',
     'category': 'Localization/Chile',
     'license': 'LGPL-3',
     'icon': '/account/static/description/l10n.png',
     'sequence': 12,
-    'author': 'Blanco Martín y Asociados',
+    'author': 'Blanco Martín y Asociados SpA',
     'summary': 'Agrega el campo TpoTranVenta al DTE según el tipo de actividad de venta.',
     'description': """
     Agrega el tag <TpoTranVenta> al XML del DTE para documentos que no son boletas ni exportaciones.
@@ -14,7 +14,7 @@
     - 2: Ventas de activo fijo
     - 3: Otras ventas
     """,
-    'website': 'http://www.bmya.cl',
+    'website': 'https://www.bmya.cl',
     'depends': [
         'l10n_cl_edi',
     ],

--- a/l10n_cl_edi_tpovta_fix/template/dte_template.xml
+++ b/l10n_cl_edi_tpovta_fix/template/dte_template.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <data>
         <template id="dte_subtemplate" inherit_id="l10n_cl_edi.dte_subtemplate">

--- a/l10n_cl_partner_extra_xml_identification/__manifest__.py
+++ b/l10n_cl_partner_extra_xml_identification/__manifest__.py
@@ -1,10 +1,10 @@
 {
     "name": """Chile - Partner XML Identification""",
-    'version': '19.0.1.0.0',
+    'version': '1.0.0',
     'category': 'Localization/Chile',
     'license': 'LGPL-3',
     'sequence': 12,
-    'author':  'Blanco Martín & Asociados',
+    'author': 'Blanco Martín y Asociados SpA',
     'summary': 'Ciertos clientes que usan SAP validan CdgVendedor y CdgIntRecep en la factura para identificar al proveedor y exigen que dicho campo no obligatorio esté en la factura. Este modulo resuelve ese gap.',
     'description': """
 Agrega Campos Especiales a los XML
@@ -12,7 +12,7 @@ Agrega Campos Especiales a los XML
 //Emisor/CdgVendedor
 //Receptor/CdgIntRecep
     """,
-    'website': 'http://blancomartin.cl',
+    'website': 'https://www.bmya.cl',
     'depends': [
         'l10n_cl_edi',
     ],

--- a/l10n_cl_partner_extra_xml_identification/template/dte_template.xml
+++ b/l10n_cl_partner_extra_xml_identification/template/dte_template.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <data>
         <template id="dte_subtemplate" inherit_id="l10n_cl_edi.dte_subtemplate">

--- a/l10n_cl_partner_extra_xml_identification/views/partner_view.xml
+++ b/l10n_cl_partner_extra_xml_identification/views/partner_view.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <data>
         <record id="view_partner_l10n_cl_edi_form" model="ir.ui.view">

--- a/l10n_cl_report_invoice_cedible/__manifest__.py
+++ b/l10n_cl_report_invoice_cedible/__manifest__.py
@@ -1,9 +1,9 @@
 {
     'name': 'Chile - Accounting Report Invoice Cedible',
     'icon': '/l10n_cl/static/description/icon.png',
-    'version': '19.0.1.0.0',
+    'version': '1.0.0',
     'category': 'Accounting/Localizations/Reporting',
-    'author': 'Blanco Martín & Asociados',
+    'author': 'Blanco Martín y Asociados SpA',
     'summary': 'Módulo que permite la impresión de la factura cedible, como un documento separado a la factura. Incorpora en el PDF las leyendas para que la cedible sea firmada y la leyenda CEDIBLE',
     'description': """
         Accounting Accounting Report Invoice Cedible for Chile
@@ -16,6 +16,6 @@
     ],
     'installable': True,
     'auto_install': True,
-    'website': 'http://www.bmya.cl',
+    'website': 'https://www.bmya.cl',
     'license': "LGPL-3",
 }

--- a/l10n_cl_report_invoice_cedible/templates/report_invoice.xml
+++ b/l10n_cl_report_invoice_cedible/templates/report_invoice.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <template id="report_invoice_transferable_table" inherit_id="l10n_cl.report_invoice_document">
         <xpath expr="//div[@name='transferable-table']" position="attributes">

--- a/picking_from_xls/__manifest__.py
+++ b/picking_from_xls/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': 'Picking from XLS File',
-    'author': 'Blanco Martín & Asociados',
+    'author': 'Blanco Martín y Asociados SpA',
     'category': 'Inventory',
     'depends': ['stock'],
     'external_dependencies': {
@@ -16,7 +16,7 @@
     'data': [
         'views/stock_picking_view.xml',
         ],
-    'version': '19.0.1.0.0',
+    'version': '1.0.0',
     'website': 'https://www.bmya.cl',
     'installable': False,
     'auto-install': False

--- a/picking_from_xls/views/stock_picking_view.xml
+++ b/picking_from_xls/views/stock_picking_view.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <record id="view_picking_inherited_form" model="ir.ui.view">
         <field name="name">stock.picking.form</field>

--- a/purchase_order_report/__manifest__.py
+++ b/purchase_order_report/__manifest__.py
@@ -1,9 +1,9 @@
 {
     'name': 'Purchase Order Report',
     'summary': """Este modulo modifica el formato de las ordenes de compra para adaptarse a los formatos chilenos (recuadro margen superior derecho).""",
-    'version': '19.0.1.0.0',
+    'version': '1.0.0',
     'license': 'LGPL-3',
-    'author': 'Blanco Martín & Asociados',
+    'author': 'Blanco Martín y Asociados SpA',
     'website': 'https://www.bmya.cl',
     'depends': [
         'purchase',

--- a/purchase_order_report/views/purchase_order_report.xml
+++ b/purchase_order_report/views/purchase_order_report.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <!-- this header can be used on any Chilean report -->
     <template id="external_layout_bmya">

--- a/sale_order_report/__manifest__.py
+++ b/sale_order_report/__manifest__.py
@@ -4,9 +4,9 @@
 {
     'name': 'Sale Order Report',
     'summary': """Este modulo modifica el formato de las ordenes de venta para adaptarse a los formatos chilenos (recuadro margen superior derecho).""",
-    'version': '19.0.1.0.0',
+    'version': '1.0.0',
     'license': 'LGPL-3',
-    'author': 'Blanco Martín & Asociados',
+    'author': 'Blanco Martín y Asociados SpA',
     'website': 'https://www.bmya.cl',
     'depends': [
         'sale',

--- a/sale_order_report/views/sale_order_report.xml
+++ b/sale_order_report/views/sale_order_report.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <!-- this header can be used on any Chilean report -->
     <template id="external_layout_bmya">


### PR DESCRIPTION
## Summary

Reset estructural de `master` para alinearlo con `19.0` y dejarlo apto para Odoo master (alpha de 20.0). Parte del rollout del plan de reset (pilot: bmya-tools#4 ya mergeada).

## Cambios

1. **`aggregation.yml`**: refs `19.0` → `master` (donde aplique).
2. **Manifests**:
   - `'version': '19.0.X.Y.Z'` → `'X.Y.Z'` (bare 3-part)
   - `'author'` → `'Blanco Martín y Asociados SpA'` (canónica)
   - `'website'` → `'https://www.bmya.cl'`

## Por qué bare version

Odoo `check_version` exige `version.startswith(release.major_version + '.')`. Hoy `release.major_version = '19.4'`. Cualquier prefijo hardcoded (`19.0.X` o `20.0.X`) marca el módulo `installable=False`. La version bare hace que Odoo prependa el serie en runtime: `19.4.1.0.0` ahora, `20.0.1.0.0` cuando SA renombre master.

Aplicado con `scripts/normalize-master-manifests.py` de bmya-infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)