### PR TITLE
[FIX] l10n_cl_edi_fix_validation: improve validations to prevent

### DIFF
--- a/l10n_cl_edi_fix_validation/__manifest__.py
+++ b/l10n_cl_edi_fix_validation/__manifest__.py
@@ -5,11 +5,14 @@
     'description': 'Evita rechazos por parte del SII por falta de algunos campos obligatorios. Inicialmente la comuna, '
                    'que se encuentra en el campo Ciudad',
     'category': 'Localization',
-    'author': 'Blanco Martín & Asociados',
+    'author': 'Blanco Martín y Asociados SpA',
     'website': 'https://www.bmya.cl',
     'license': 'OPL-1',
     'depends': [
         'l10n_cl_edi',
+    ],
+    'data': [
+        'views/res_config_settings.xml',
     ],
     'installable': True,
     'auto_install': True

--- a/l10n_cl_edi_fix_validation/i18n/es_419.po
+++ b/l10n_cl_edi_fix_validation/i18n/es_419.po
@@ -55,3 +55,81 @@ msgid ""
 "The person"
 msgstr ""
 "El contacto"
+
+#. module: l10n_cl_edi_fix_validation
+#. odoo-python
+#: code:l10n_cl_edi_fix_validation/models/account_move.py:0
+#, python-format
+msgid ""
+"You cannot issue an electronic document to yourself. The issuer RUT "
+"%(vat)s is the same as the receiver RUT."
+msgstr ""
+"No puede emitir un documento electrónico a sí mismo. El RUT emisor "
+"%(vat)s es el mismo que el RUT receptor."
+
+#. module: l10n_cl_edi_fix_validation
+#. odoo-python
+#: code:l10n_cl_edi_fix_validation/models/account_move.py:0
+#, python-format
+msgid ""
+"The tax period for %(date)s is already closed at the SII (closing day: "
+"%(day)s of the following month). Please use the current period or adjust "
+"the invoice date."
+msgstr ""
+"El período tributario de %(date)s ya está cerrado en el SII (día de "
+"cierre: %(day)s del mes siguiente). Por favor use el período actual o "
+"ajuste la fecha del documento."
+
+#. module: l10n_cl_edi_fix_validation
+#: model:ir.model.fields,field_description:l10n_cl_edi_fix_validation.field_res_config_settings__l10n_cl_block_self_invoice
+msgid "Block self-invoicing"
+msgstr "Bloquear auto-facturación"
+
+#. module: l10n_cl_edi_fix_validation
+#: model:ir.model.fields,help:l10n_cl_edi_fix_validation.field_res_config_settings__l10n_cl_block_self_invoice
+msgid "Prevent issuing an electronic document where the issuer and receiver have the same RUT."
+msgstr "Impide emitir un documento electrónico cuando el emisor y el receptor tienen el mismo RUT."
+
+#. module: l10n_cl_edi_fix_validation
+#: model:ir.model.fields,field_description:l10n_cl_edi_fix_validation.field_res_config_settings__l10n_cl_block_period_closed
+msgid "Block documents from a closed SII period"
+msgstr "Bloquear documentos de un período cerrado en el SII"
+
+#. module: l10n_cl_edi_fix_validation
+#: model:ir.model.fields,help:l10n_cl_edi_fix_validation.field_res_config_settings__l10n_cl_block_period_closed
+msgid ""
+"Prevent issuing electronic documents dated in a month already closed at "
+"the SII, even if the accounting period itself is not locked."
+msgstr ""
+"Impide emitir documentos electrónicos con fecha en un mes ya cerrado en "
+"el SII, aunque el período contable no esté bloqueado."
+
+#. module: l10n_cl_edi_fix_validation
+#: model:ir.model.fields,field_description:l10n_cl_edi_fix_validation.field_res_config_settings__l10n_cl_period_closing_day
+msgid "SII period closing day"
+msgstr "Día de cierre de período SII"
+
+#. module: l10n_cl_edi_fix_validation
+#: model:ir.model.fields,help:l10n_cl_edi_fix_validation.field_res_config_settings__l10n_cl_period_closing_day
+msgid "Day of the month on which the SII closes the previous month's tax period."
+msgstr "Día del mes en que el SII cierra el período tributario del mes anterior."
+
+#. module: l10n_cl_edi_fix_validation
+#: model_terms:ir.ui.view,arch_db:l10n_cl_edi_fix_validation.res_config_settings_view_form
+msgid "Electronic Invoicing Extra Validations"
+msgstr "Validaciones adicionales de facturación electrónica"
+
+#. module: l10n_cl_edi_fix_validation
+#: model_terms:ir.ui.view,arch_db:l10n_cl_edi_fix_validation.res_config_settings_view_form
+msgid "Blocks documents where the issuer RUT matches the receiver RUT"
+msgstr "Bloquea documentos donde el RUT emisor coincide con el RUT receptor"
+
+#. module: l10n_cl_edi_fix_validation
+#: model_terms:ir.ui.view,arch_db:l10n_cl_edi_fix_validation.res_config_settings_view_form
+msgid "Blocks documents dated in a tax period already closed at the SII"
+msgstr "Bloquea documentos con fecha en un período tributario ya cerrado en el SII"
+
+#. module: l10n_cl_edi_fix_validation
+#: model_terms:ir.ui.view,arch_db:l10n_cl_edi_fix_validation.res_config_settings_view_form
+msgid "Closing day"
+msgstr "Día de cierre"

--- a/l10n_cl_edi_fix_validation/models/__init__.py
+++ b/l10n_cl_edi_fix_validation/models/__init__.py
@@ -1,1 +1,1 @@
-from . import account_move
+from . import account_move, res_config_settings

--- a/l10n_cl_edi_fix_validation/models/account_move.py
+++ b/l10n_cl_edi_fix_validation/models/account_move.py
@@ -1,5 +1,6 @@
-from odoo import models
+from odoo import fields, models
 from odoo.exceptions import UserError
+from odoo.tools import str2bool
 from odoo.tools.translate import _
 
 
@@ -11,12 +12,35 @@ class AccountMove(models.Model):
         if self.l10n_cl_journal_point_of_sale_type == 'online':
             if not (self.partner_id.city or self.commercial_partner_id.city):
                 raise UserError(
-                    _('%(company_type)s %(partner)s has not a comune or city defined. This is mandatory for '
-                      'electronic invoicing. Please edit the contact and set one.',
-                    company_type=_('The company') if self.partner_id.company_type == 'company' else _('The person'),
-                    partner=self.partner_id.name))
+                    _(
+                        '%(company_type)s %(partner)s has not a comune or city defined. This is mandatory for '
+                        'electronic invoicing. Please edit the contact and set one.',
+                        company_type=_('The company') if self.partner_id.company_type == 'company' else _('The person'),
+                        partner=self.partner_id.name,
+                    )
+                )
         if not self.company_id.city:
             raise UserError(_(
                 'Your company has not a comune or city defined. This is mandatory for electronic '
                 'invoicing. Please go to your company data, and set the correct one.'))
+
+        icp = self.env['ir.config_parameter'].sudo()
+        if str2bool(icp.get_param('l10n_cl_edi_fix_validation.block_self_invoice', 'True')):
+            company_vat = self.company_id.vat
+            partner_vat = self.commercial_partner_id.vat
+            if company_vat and partner_vat and (
+                    self._l10n_cl_format_vat(company_vat) == self._l10n_cl_format_vat(partner_vat)):
+                raise UserError(_(
+                    'You cannot issue an electronic document to yourself. The issuer RUT '
+                    '%(vat)s is the same as the receiver RUT.', vat=company_vat))
+
+        if str2bool(icp.get_param('l10n_cl_edi_fix_validation.block_period_closed', 'True')):
+            closing_day = int(icp.get_param('l10n_cl_edi_fix_validation.period_closing_day', '20'))
+            today = fields.Date.context_today(self)
+            months_diff = (today.year - self.invoice_date.year) * 12 + (today.month - self.invoice_date.month)
+            if months_diff >= 2 or (months_diff == 1 and today.day >= closing_day):
+                raise UserError(_(
+                    'The tax period for %(date)s is already closed at the SII (closing day: %(day)s of '
+                    'the following month). Please use the current period or adjust the invoice date.',
+                    date=self.invoice_date, day=closing_day))
         return res

--- a/l10n_cl_edi_fix_validation/models/res_config_settings.py
+++ b/l10n_cl_edi_fix_validation/models/res_config_settings.py
@@ -1,0 +1,22 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    l10n_cl_block_self_invoice = fields.Boolean(
+        string="Block self-invoicing",
+        config_parameter='l10n_cl_edi_fix_validation.block_self_invoice',
+        default=True,
+        help="Prevent issuing an electronic document where the issuer and receiver have the same RUT.")
+    l10n_cl_block_period_closed = fields.Boolean(
+        string="Block documents from a closed SII period",
+        config_parameter='l10n_cl_edi_fix_validation.block_period_closed',
+        default=True,
+        help="Prevent issuing electronic documents dated in a month already closed at the SII, "
+             "even if the accounting period itself is not locked.")
+    l10n_cl_period_closing_day = fields.Integer(
+        string="SII period closing day",
+        config_parameter='l10n_cl_edi_fix_validation.period_closing_day',
+        default=20,
+        help="Day of the month on which the SII closes the previous month's tax period.")

--- a/l10n_cl_edi_fix_validation/views/res_config_settings.xml
+++ b/l10n_cl_edi_fix_validation/views/res_config_settings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.l10n.cl.edi.fix.validation</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="l10n_cl.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//block[@id='l10n_cl_section']" position="after">
+                <block title="Electronic Invoicing Extra Validations" id="l10n_cl_edi_fix_validation_section"
+                       invisible="country_code != 'CL'">
+                    <setting id="l10n_cl_edi_fix_validation_self_invoice_setting"
+                             help="Blocks documents where the issuer RUT matches the receiver RUT">
+                        <field name="l10n_cl_block_self_invoice"/>
+                    </setting>
+                    <setting id="l10n_cl_edi_fix_validation_period_setting"
+                             help="Blocks documents dated in a tax period already closed at the SII">
+                        <div class="content-group">
+                            <div class="row">
+                                <field name="l10n_cl_block_period_closed" style="width: 10% !important;"/>
+                                <label for="l10n_cl_block_period_closed" class="col-lg-10 o_light_label"/>
+                            </div>
+                            <div class="row" invisible="not l10n_cl_block_period_closed">
+                                <label string="Closing day" for="l10n_cl_period_closing_day"
+                                       class="col-lg-4 o_light_label"/>
+                                <field name="l10n_cl_period_closing_day"/>
+                            </div>
+                        </div>
+                    </setting>
+                </block>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Before this PR:
You must close invoicing date to prevent electronic invoices errors, like
- invoicing in not allowed dates
- invoicing to self company
After this PR:
l10n_cl_edi_fix_validation: take care of this, and the values are configurable in config panel using parameters